### PR TITLE
Introduce ReLU activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Il cuore del progetto: implementazione da zero di una rete neurale feedforward c
 - **Feedforward** - Propagazione del segnale attraverso la rete
 - **Backpropagation** - Calcolo dell'errore e aggiustamento dei pesi
 - **Dropout** - Tecnica per prevenire l'overfitting
-- **Funzioni di attivazione** - Implementazione manuale della funzione sigmoide
+- **Funzioni di attivazione** - Implementazioni di Sigmoide e ReLU
 
 ### `RealEstateNeuralNetwork.java`
 
@@ -196,7 +196,7 @@ Interfaccia generica per la normalizzazione dei dati:
 Essendo un progetto dimostrativo, presenta alcune limitazioni:
 
 - **Performance** - Non ottimizzato per grandi dataset (usa calcoli naïf)
-- **Funzioni di attivazione** - Implementa solo la funzione sigmoide
+- **Funzioni di attivazione** - Supporta Sigmoide e ReLU
 - **Architettura** - Supporta solo una topologia fissa con un singolo strato nascosto
 - **Batch processing** - Non implementa il mini-batch gradient descent
 

--- a/src/main/java/it/bove/application/RealEstateNeuralNetwork.java
+++ b/src/main/java/it/bove/application/RealEstateNeuralNetwork.java
@@ -4,6 +4,7 @@ import it.bove.infrastructure.normalization.DefaultFeatureNormalizer;
 import it.bove.infrastructure.normalization.DefaultPriceNormalizer;
 import it.bove.infrastructure.nn.NeuralNetworkAdapter;
 import it.bove.core.nn.NeuralNetwork;
+import it.bove.core.activation.ReLUActivationFunction;
 import it.bove.core.nn.NeuralNetworkModel;
 import it.bove.domain.realestate.FeatureNormalizer;
 import it.bove.domain.realestate.PriceNormalizer;
@@ -51,8 +52,8 @@ public class RealEstateNeuralNetwork {
      * Utilizza una rete neurale standard e parametri di normalizzazione comunemente usati.
      */
     public RealEstateNeuralNetwork() {
-        // Creiamo una rete neurale standard: 5 input (caratteristiche), 8 neuroni nascosti, 1 output (prezzo)
-        this.model = new NeuralNetworkAdapter(new NeuralNetwork(5, 8, 1, 0.05, 0.1));
+        // Creiamo una rete neurale con ReLU: 5 input, 8 neuroni nascosti, 1 output (prezzo)
+        this.model = new NeuralNetworkAdapter(new NeuralNetwork(5, 8, 1, 0.05, 0.1, new ReLUActivationFunction()));
 
         // Definiamo i parametri di normalizzazione basati su analisi statistiche del mercato immobiliare
         this.featureNormalizer = new DefaultFeatureNormalizer(new double[]{30.0, 1.0, 1.0, 0.0, 1.0},   // Valori minimi: mq, stanze, bagni, piano, zona

--- a/src/main/java/it/bove/core/activation/ActivationFunction.java
+++ b/src/main/java/it/bove/core/activation/ActivationFunction.java
@@ -1,0 +1,23 @@
+package it.bove.core.activation;
+
+/**
+ * Funzione di attivazione per i neuroni della rete neurale.
+ */
+public interface ActivationFunction {
+    /**
+     * Applica la funzione di attivazione.
+     *
+     * @param x valore di input
+     * @return valore dopo l'attivazione
+     */
+    double activate(double x);
+
+    /**
+     * Calcola la derivata della funzione di attivazione.
+     * L'argomento è il valore già attivato per semplicità.
+     *
+     * @param activated output della funzione di attivazione
+     * @return derivata valutata sull'output
+     */
+    double derivative(double activated);
+}

--- a/src/main/java/it/bove/core/activation/ReLUActivationFunction.java
+++ b/src/main/java/it/bove/core/activation/ReLUActivationFunction.java
@@ -1,0 +1,16 @@
+package it.bove.core.activation;
+
+/**
+ * Funzione di attivazione ReLU (Rectified Linear Unit).
+ */
+public class ReLUActivationFunction implements ActivationFunction {
+    @Override
+    public double activate(double x) {
+        return Math.max(0.0, x);
+    }
+
+    @Override
+    public double derivative(double activated) {
+        return activated > 0.0 ? 1.0 : 0.0;
+    }
+}

--- a/src/main/java/it/bove/core/activation/SigmoidActivationFunction.java
+++ b/src/main/java/it/bove/core/activation/SigmoidActivationFunction.java
@@ -1,0 +1,16 @@
+package it.bove.core.activation;
+
+/**
+ * Implementazione della funzione sigmoide.
+ */
+public class SigmoidActivationFunction implements ActivationFunction {
+    @Override
+    public double activate(double x) {
+        return 1.0 / (1.0 + Math.exp(-x));
+    }
+
+    @Override
+    public double derivative(double activated) {
+        return activated * (1.0 - activated);
+    }
+}

--- a/src/main/java/it/bove/core/nn/NeuralNetwork.java
+++ b/src/main/java/it/bove/core/nn/NeuralNetwork.java
@@ -3,6 +3,9 @@ package it.bove.core.nn;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import it.bove.core.activation.ActivationFunction;
+import it.bove.core.activation.SigmoidActivationFunction;
+
 import java.util.Random;
 
 /**
@@ -30,6 +33,8 @@ public class NeuralNetwork {
     private final double dropoutRate;
     // Random per il dropout
     private final Random rand;
+    // Funzione di attivazione utilizzata dai neuroni
+    private final ActivationFunction activationFunction;
 
     /**
      * Costruttore per la classe NeuralNetwork.
@@ -41,6 +46,13 @@ public class NeuralNetwork {
      * @param dropoutRate  Tasso di dropout per disattivare casualmente i neuroni durante l'addestramento.
      */
     public NeuralNetwork(int inputSize, int hiddenSize, int outputSize, double learningRate, double dropoutRate) {
+        this(inputSize, hiddenSize, outputSize, learningRate, dropoutRate, new SigmoidActivationFunction());
+    }
+
+    /**
+     * Costruttore che permette di specificare una funzione di attivazione.
+     */
+    public NeuralNetwork(int inputSize, int hiddenSize, int outputSize, double learningRate, double dropoutRate, ActivationFunction activationFunction) {
         log.debug("Creazione di una nuova rete neurale con {} neuroni di input, {} neuroni nascosti, {} neuroni di output, tasso di apprendimento {} e tasso di dropout {}", inputSize, hiddenSize, outputSize, learningRate, dropoutRate);
 
         // Inizializza la matrice dei pesi tra input e nascosto
@@ -57,6 +69,8 @@ public class NeuralNetwork {
         this.dropoutRate = dropoutRate;
         // Inizializza l'oggetto Random
         this.rand = new Random();
+        // Imposta la funzione di attivazione
+        this.activationFunction = activationFunction;
 
         // Chiama il metodo per inizializzare i pesi con valori casuali
         initializeWeights();
@@ -147,8 +161,8 @@ public class NeuralNetwork {
             for (int j = 0; j < inputs.length; j++) { // Ciclo per ogni neurone di input
                 outputs[i] += inputs[j] * weights[j][i]; // Somma il prodotto dell'input e del peso al valore del neurone di output
             }
-            outputs[i] = sigmoid(outputs[i]); // Applica la funzione sigmoide al valore del neurone di output
-            log.debug("Valore del neurone {} dopo l'applicazione della funzione sigmoide: {}", i, outputs[i]);
+            outputs[i] = activationFunction.activate(outputs[i]); // Applica la funzione di attivazione
+            log.debug("Valore del neurone {} dopo l'applicazione della funzione di attivazione: {}", i, outputs[i]);
         }
     }
 
@@ -259,7 +273,7 @@ public class NeuralNetwork {
         for (int i = 0; i < weights.length; i++) { // Ciclo per ogni neurone di input
             for (int j = 0; j < weights[i].length; j++) { // Ciclo per ogni neurone di output
                 // Aggiorna il peso tra neurone di input e neurone di output
-                weights[i][j] += learningRate * layerErrors[j] * sigmoidDerivative(layerOutputs[j]) * layerInputs[i];
+                weights[i][j] += learningRate * layerErrors[j] * activationFunction.derivative(layerOutputs[j]) * layerInputs[i];
                 log.debug("Aggiornamento del peso tra il neurone {} e il neurone {}: nuovo peso {}", i, j, weights[i][j]);
             }
         }


### PR DESCRIPTION
## Summary
- add generic `ActivationFunction` interface
- implement `SigmoidActivationFunction` and `ReLUActivationFunction`
- allow `NeuralNetwork` to accept an activation function
- use ReLU in the default `RealEstateNeuralNetwork`
- document new activation options in README

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2ecd7dc48322a54ef456e21146b1